### PR TITLE
don't crash on undefined opts in addNewKeyring

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ class KeyringController extends EventEmitter {
   // All Keyring classes implement a unique `type` string,
   // and this is used to retrieve them from the keyringTypes array.
   async addNewKeyring (type, opts) {
-    if (opts.password) {
+    if (opts && opts.password) {
       this.password = opts.password
       opts.encryptionKey = await this._getSubkey('ethwallet-encryptor')
     }

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ const configManagerGen = require('./lib/mock-config-manager')
 const ethUtil = require('ethereumjs-util')
 const BN = ethUtil.BN
 const mockEncryptor = require('./lib/mock-encryptor')
+const MockSimpleKeyring = require('./lib/mock-simple-keyring')
 const sinon = require('sinon')
 const argon2 = require('argon2-wasm')
 
@@ -118,6 +119,22 @@ describe('KeyringController', () => {
       const allAccounts = await keyringController.getAccounts()
       assert.deepEqual(allAccounts.length, 1 + previousAccounts.length,
         'allAccounts match expectation')
+    })
+    it('Mocked Simple Key Pair (no opts)', async () => {
+      keyringController = new KeyringController({
+        configManager: configManagerGen(),
+        encryptor: mockEncryptor,
+        keyringTypes: [MockSimpleKeyring]
+      })
+
+      await keyringController.createNewVaultAndKeychain(password)
+
+      const previousKeyrings = await keyringController.getKeyringsByType('Mocked Simple Key Pair')
+      assert.equal(previousKeyrings.length, 0, 'no keyrings')
+
+      await keyringController.addNewKeyring('Mocked Simple Key Pair')
+      const keyrings = await keyringController.getKeyringsByType('Mocked Simple Key Pair')
+      assert.equal(keyrings.length, 1, 'found mocked keyring')
     })
   })
 

--- a/test/lib/mock-simple-keyring.js
+++ b/test/lib/mock-simple-keyring.js
@@ -1,0 +1,43 @@
+// based on https://github.com/MetaMask/eth-simple-keyring/blob/master/index.js
+
+var fakeWallet = {
+  privKey: '0x123456788890abcdef',
+  address: '0xfedcba0987654321',
+}
+const type = 'Mocked Simple Key Pair'
+
+class MockSimpleKeyring {
+
+  static type () { return type }
+
+  constructor (opts) {
+    this.type = type
+    this.opts = opts || {}
+    this.wallets = []
+  }
+
+  serialize () {
+    return [ fakeWallet.privKey ]
+  }
+
+  deserialize (data) {
+    if (!Array.isArray(data)) {
+      throw new Error('Simple keychain deserialize requires a privKey array.')
+    }
+    this.wallets = [ fakeWallet ]
+  }
+
+  addAccounts (n = 1) {
+    for (var i = 0; i < n; i++) {
+      this.wallets.push(fakeWallet)
+    }
+  }
+
+  getAccounts () {
+    return Promise.resolve(this.wallets.map(w => w.address))
+  }
+
+}
+
+MockSimpleKeyring.type = type
+module.exports = MockSimpleKeyring


### PR DESCRIPTION
This fixes the "Cannot read property 'password' of undefined" errors when using hardware wallets.