### PR TITLE
Fixing verify password method

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,11 +193,11 @@ class KeyringController extends EventEmitter {
    * @param {string} password
    */
   async verifyPassword (password) {
-    const encryptedVault = this.store.getState().vault
-    if (!encryptedVault) {
-      throw new Error('Cannot unlock without a previous vault.')
-    }
-    await this.encryptor.decrypt(password, encryptedVault)
+    this.masterKey = null
+    return this.unlockKeyrings(password)
+    .then((keyrings) => {
+      this.keyrings = keyrings
+    })
   }
 
   // Add New Keyring


### PR DESCRIPTION
The previous method worked fine upstream, but wasn't enough, as it didn't take our salt/argonParams in to account for decryption. This is essentially a copy of `submitPassword`, it just hinge logging in/out on whether the password is correct or not.