### PR TITLE
Eagerly clean module cache when using argon2.hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,49 +21,47 @@ const KEY_LENGTH = 32 // default key length in bytes
 const TextEncoder = window.TextEncoder || require('util').TextEncoder
 const TextDecoder = window.TextDecoder || require('util').TextDecoder
 
-
-let moduleCacheTmp = arguments[5]
-const MODULE_CACHE = moduleCacheRef()
-
-function moduleCacheRef() {
+const moduleCacheRef = (moduleCache) => {
   if (window.WeakRef) {
-    let ref = new WeakRef(moduleCacheTmp)
-    moduleCacheTmp = null
+    let ref = new window.WeakRef(moduleCache)
+    moduleCache = null
     return ref
   }
 
   try {
     const weak = require('weak')
     let ref = {
-      _ref: weak(moduleCacheTmp),
-      deref() {
+      _ref: weak(moduleCache),
+      deref () {
         return weak.isDead(this._ref) ? null : this._ref
       }
     }
 
-    moduleCacheTmp = null;
+    moduleCache = null
     return ref
   } catch (e) {
   }
 
   return {
-    deref() { return moduleCacheTmp }
+    deref () { return moduleCache }
   }
 }
 
-function clearFromCache(instance) {
-  let moduleCache = MODULE_CACHE.deref()
+const clearFromCache = (instance) => {
+  const moduleCache = MODULE_CACHE.deref()
   if (!moduleCache) {
     return
   }
 
   for (let key in moduleCache) {
-    if (moduleCache[key].exports == instance) {
+    if (moduleCache[key].exports === instance) {
       delete moduleCache[key]
       return
     }
   }
 }
+
+const MODULE_CACHE = moduleCacheRef(arguments[5])
 
 /**
  * Converts a string to a uint8array

--- a/index.js
+++ b/index.js
@@ -22,7 +22,34 @@ const TextEncoder = window.TextEncoder || require('util').TextEncoder
 const TextDecoder = window.TextDecoder || require('util').TextDecoder
 
 
-const MODULE_CACHE = new WeakRef(arguments[5])
+let moduleCacheTmp = arguments[5]
+const MODULE_CACHE = moduleCacheRef()
+
+function moduleCacheRef() {
+  if (window.WeakRef) {
+    let ref = new WeakRef(moduleCacheTmp)
+    moduleCacheTmp = null
+    return ref
+  }
+
+  try {
+    const weak = require('weak')
+    let ref = {
+      _ref: weak(moduleCacheTmp),
+      deref() {
+        return weak.isDead(this._ref) ? null : this._ref
+      }
+    }
+
+    moduleCacheTmp = null;
+    return ref
+  } catch (e) {
+  }
+
+  return {
+    deref() { return moduleCacheTmp }
+  }
+}
 
 function clearFromCache(instance) {
   let moduleCache = MODULE_CACHE.deref()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Brave's fork of the Metamask module for managing various keyrings of Ethereum accounts, encrypting them, and using them.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --require test/helper.js test/index.js --timeout 6000"
+    "test": "mocha --require test/helper.js test/index.js --timeout 10000"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,8 @@
     "jsdom-global": "^3.0.2",
     "mocha": "^8.0.1",
     "polyfill-crypto.getrandomvalues": "^1.0.0",
-    "sinon": "^7.2.7"
+    "sinon": "^7.2.7",
+    "weak": "^1.0.1"
   },
   "dependencies": {
     "argon2-wasm": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,6 +436,13 @@ binary-search@^1.3.3:
   resolved "https://registry.yarnpkg.com/binary-search/-/binary-search-1.3.6.tgz#e32426016a0c5092f0f3598836a1c7da3560565c"
   integrity sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==
 
+bindings@^1.2.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bip39@^2.2.0, bip39@^2.4.0, bip39@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.6.0.tgz#9e3a720b42ec8b3fbe4038f1e445317b6a99321c"
@@ -992,7 +999,7 @@ eth-hd-keyring@brave/eth-hd-keyring#bb10a3502568597197260f39165fd44af74a401e:
   resolved "https://codeload.github.com/brave/eth-hd-keyring/tar.gz/bb10a3502568597197260f39165fd44af74a401e"
   dependencies:
     bip39 "^2.2.0"
-    brave-crypto "^0.3.1"
+    brave-crypto "^0.2.1"
     eth-sig-util "^2.2.0"
     ethereumjs-util "^6.1.0"
     ethereumjs-wallet "^0.6.3"
@@ -1197,6 +1204,11 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1802,6 +1814,11 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nan@^2.0.5:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nanoid@3.1.12:
   version "3.1.12"
@@ -2597,6 +2614,14 @@ w3c-hr-time@^1.0.1:
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
   dependencies:
     browser-process-hrtime "^1.0.0"
+
+weak@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/weak/-/weak-1.0.1.tgz#ab99aab30706959aa0200cb8cf545bb9cb33b99e"
+  integrity sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.0.5"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Fixes brave/brave-browser#13438

The heap that's allocated for argon2-wasm ends up living in the module.exports, which is cached so require('..') is faster. Since we are allocating 500MB for hashing, it means creation of a new wallet or unlocking will holding onto an add'l 500MB after hashing, which we probably don't want!

the best solution would be to do this purely in native C and manage the heap directly, however since we're moving to BIP39, there probably isn't much reason to go that way

/cc @ryanml @diracdeltas 